### PR TITLE
Replace remaining console.logs with logger

### DIFF
--- a/src/application/check-in/use-case/check-in.usecase.ts
+++ b/src/application/check-in/use-case/check-in.usecase.ts
@@ -15,6 +15,7 @@ import {
 import type { PrismaUnitOfWork } from '@/infra/database/repository/unit-of-work/unit-of-work'
 import { TYPES } from '@/infra/ioc/types'
 import type { Queue } from '@/infra/queue/queue'
+import type { Logger } from '@/infra/logger/logger'
 
 import type { GymRepository } from '../../gym/repository/gym-repository'
 import { UserHasAlreadyCheckedInToday } from '../../user/error/user-has-already-checked-in-today'
@@ -58,6 +59,8 @@ export class CheckInUseCase {
     private readonly queue: Queue,
     @inject(TYPES.Prisma.UnitOfWork)
     private readonly unityOfWork: PrismaUnitOfWork,
+    @inject(TYPES.Logger)
+    private readonly logger: Logger,
   ) {
     this.bindMethod()
   }
@@ -137,8 +140,8 @@ export class CheckInUseCase {
   private async createDomainEventSubscriber(
     event: CheckInCreatedEvent,
   ): Promise<void> {
-    console.log('**************')
-    console.log(event)
+    this.logger.info(this, 'checkInCreated event received')
+    this.logger.info(this, event)
     this.queue.publish(event.eventName, event)
   }
 

--- a/src/application/user/use-case/create-user.usecase.ts
+++ b/src/application/user/use-case/create-user.usecase.ts
@@ -6,6 +6,7 @@ import { User, type UserValidationErrors } from '@/domain/user/user'
 import type { RoleTypes } from '@/domain/user/value-object/role'
 import { TYPES } from '@/infra/ioc/types'
 import type { Queue } from '@/infra/queue/queue'
+import type { Logger } from '@/infra/logger/logger'
 
 import {
   type Either,
@@ -44,6 +45,8 @@ export class CreateUserUseCase {
     private readonly userRepository: UserRepository,
     @inject(TYPES.Queue)
     private readonly queue: Queue,
+    @inject(TYPES.Logger)
+    private readonly logger: Logger,
   ) {
     this.bindMethod()
   }
@@ -84,8 +87,8 @@ export class CreateUserUseCase {
   private async createDomainEventSubscriber(
     event: UserCreatedEvent,
   ): Promise<void> {
-    console.log('**************')
-    console.log(event)
+    this.logger.info(this, 'userCreated event received')
+    this.logger.info(this, event)
     this.queue.publish(event.eventName, event)
   }
 

--- a/src/application/user/use-case/fetch-users.usecase.ts
+++ b/src/application/user/use-case/fetch-users.usecase.ts
@@ -47,7 +47,7 @@ export class FetchUsersUseCase {
     input: FetchUsersUseCaseInput,
   ): Promise<FetchUsersUseCaseOutput> {
     const usersCacheResult = await this.fetchUsersFromCache(input)
-    console.log({ usersCacheResult })
+    this.logger.info(this, usersCacheResult)
     if (usersCacheResult) return usersCacheResult
     const usersData = await this.userDAO.fetchAndCountUsers(input)
     void this.saveUserDataToCache(input, usersData).catch((error) => {

--- a/src/bootstrap/server-build.ts
+++ b/src/bootstrap/server-build.ts
@@ -17,13 +17,15 @@ import { TYPES } from '@/infra/ioc/types'
 import { EXCHANGES } from '@/infra/queue/exchanges'
 import type { Queue } from '@/infra/queue/queue'
 import type { FastifyAdapter } from '@/infra/server/fastify-adapter'
+import type { Logger } from '@/infra/logger/logger'
 
 interface ConstructorClass {
   new (...args: any[]): Controller
 }
 
 export async function serverBuild() {
-  console.log('TYPES.Server.Fastify', container.isBound(TYPES.Server.Fastify))
+  const logger = container.get<Logger>(TYPES.Logger)
+  logger.info(serverBuild, `TYPES.Server.Fastify ${container.isBound(TYPES.Server.Fastify)}`)
   const fastifyServer = container.get<FastifyAdapter>(TYPES.Server.Fastify)
   const userController = resolve(CreateUserController)
   const authenticateController = resolve(AuthenticateController)

--- a/src/infra/auth/json-web-token-adapter.ts
+++ b/src/infra/auth/json-web-token-adapter.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
 import jwt, { type SignOptions } from 'jsonwebtoken'
 
 import {
@@ -10,9 +10,12 @@ import {
 import type { AuthToken, Payload } from '../../application/user/auth/auth-token'
 import { InvalidUserTokenError } from '../../application/user/error/invalid-user-token-error'
 import { env } from '../env'
+import { TYPES } from '../ioc/types'
+import type { Logger } from '../logger/logger'
 
 @injectable()
 export class JsonWebTokenAdapter implements AuthToken {
+  constructor(@inject(TYPES.Logger) private readonly logger: Logger) {}
   public sign(payload: Payload, privateKey: string): string {
     return jwt.sign(payload, privateKey, {
       expiresIn: env.JWT_EXPIRES_IN as SignOptions['expiresIn'],
@@ -28,7 +31,7 @@ export class JsonWebTokenAdapter implements AuthToken {
       return success(payload)
     } catch (e) {
       if (e instanceof Error) {
-        console.log(e.message)
+        this.logger.error(this, e.message)
       }
       return failure(new InvalidUserTokenError())
     }

--- a/src/infra/controller/queue-controller.ts
+++ b/src/infra/controller/queue-controller.ts
@@ -39,7 +39,8 @@ export class QueueController implements Controller {
     this.queue.consume(
       QUEUES.NOTIFY_PASSWORD_CHANGED,
       async (event: PasswordChangedEvent): Promise<void> => {
-        console.log('Password changed event', event)
+        this.logger.info(this, 'Password changed event')
+        this.logger.info(this, event)
         const payload = event.payload
         await this.mailer.sendMail(
           payload.email,
@@ -50,15 +51,15 @@ export class QueueController implements Controller {
     )
 
     this.queue.consume(QUEUES.LOG, async (event: any): Promise<void> => {
-      console.log('QUEUE [LOG]')
-      console.log(event)
+      this.logger.info(this, 'QUEUE [LOG]')
+      this.logger.info(this, event)
     })
 
     this.queue.consume(
       QUEUES.CHECK_IN,
       async (event: CheckInCreatedEvent): Promise<void> => {
-        console.log('QUEUE [CHECK_IN]')
-        console.log(event)
+        this.logger.info(this, 'QUEUE [CHECK_IN]')
+        this.logger.info(this, event)
       },
     )
   }

--- a/src/infra/gateway/mailer-gateway-memory.ts
+++ b/src/infra/gateway/mailer-gateway-memory.ts
@@ -1,16 +1,21 @@
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
+
+import { TYPES } from '../ioc/types'
+import type { Logger } from '../logger/logger'
 
 import type { MailerGateway } from './mailer-gateway'
 
 @injectable()
 export class MailerGatewayMemory implements MailerGateway {
+  constructor(@inject(TYPES.Logger) private readonly logger: Logger) {}
+
   public async sendMail(
     to: string,
     subject: string,
     body: string,
   ): Promise<void> {
-    console.log('Sending email to', to)
-    console.log('Subject:', subject)
-    console.log('Body:', body)
+    this.logger.info(this, `Sending email to ${to}`)
+    this.logger.info(this, `Subject: ${subject}`)
+    this.logger.info(this, `Body: ${body}`)
   }
 }

--- a/src/infra/queue/queue-memory-adapter.ts
+++ b/src/infra/queue/queue-memory-adapter.ts
@@ -1,13 +1,18 @@
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
+
+import { TYPES } from '../ioc/types'
+import type { Logger } from '../logger/logger'
 
 import type { Queue } from './queue'
 
 @injectable()
 export class QueueMemoryAdapter implements Queue {
+  constructor(@inject(TYPES.Logger) private readonly logger: Logger) {}
+
   public queues: Map<string, CallableFunction[]> = new Map()
 
   async connect(): Promise<void> {
-    console.log('QueueMemoryAdapter connected')
+    this.logger.info(this, 'QueueMemoryAdapter connected')
   }
 
   async publish<TData>(exchange: string, data: TData): Promise<void> {

--- a/src/infra/queue/rabbitmq-adapter.ts
+++ b/src/infra/queue/rabbitmq-adapter.ts
@@ -1,16 +1,20 @@
 import amqp from 'amqplib'
-import { injectable } from 'inversify'
+import { inject, injectable } from 'inversify'
 
-import { Logger } from '../decorator/logger'
+import { Logger as LoggerDecorator } from '../decorator/logger'
+import { TYPES } from '../ioc/types'
+import type { Logger } from '../logger/logger'
 import { env } from '../env'
 import type { Queue } from './queue'
 
 @injectable()
 export class RabbitMQAdapter implements Queue {
+  constructor(@inject(TYPES.Logger) private readonly logger: Logger) {}
+
   private connection?: amqp.ChannelModel
   private _channel?: amqp.Channel
 
-  @Logger({
+  @LoggerDecorator({
     message: '✅',
   })
   public async connect(): Promise<void> {
@@ -26,7 +30,7 @@ export class RabbitMQAdapter implements Queue {
     const channel = await this.channel()
     await channel.assertExchange(exchange, 'direct', { durable: true })
     const buffer = Buffer.from(JSON.stringify(data))
-    console.log({ exchange })
+    this.logger.info(this, { exchange })
     channel.publish(exchange, '', buffer)
   }
   private async channel(): Promise<amqp.Channel> {


### PR DESCRIPTION
## Summary
- refactor gateway and queue adapters to use Winston logger
- inject logger into JWT adapter and server bootstrap
- log queue events with Winston
- update user and check-in use cases to use logger

## Testing
- `npm test` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae1c8d948329a44d494a59effbd1